### PR TITLE
fix: absolute path cannot be used for `input_file' in Windows environment

### DIFF
--- a/extractunitypackage.py
+++ b/extractunitypackage.py
@@ -33,7 +33,8 @@ outputDir = ''
 if len(sys.argv) > 2:
 	outputDir = os.path.join(sys.argv[2], name)
 else:
-	outputDir = './' + name
+	inputDir = os.path.dirname(sys.argv[1])
+	outputDir = os.path.join(inputDir, name)
 workingDir = './.working'
 
 # can't proceed if the output dir exists already


### PR DESCRIPTION
Hi, thanks for the useful tool!
There was a problem that did not work well in my Windows 11 environment, so I hope you will consider fixing it.

## What's changed

- The `outputDir` is now determined from the parent directory of `input_file`.

## Purpose 

- When `input_file` is an absolute path and 'output_path' is not specified, `outputDir = '. /' + '/path/to/input_file'`.
- On Windows environment, `'. /<Drive letter>:path/to/input_file'` and it does not work.

## How to reproduce the problem

## No problem

Relative path


```shell
E:\repos\extractunitypackage>python extractunitypackage.py sample_asset/sample1.unitypackage  
13a9e2db20d9c4649959049d9807cb1d => Assets/TestPackage/C1/C2/C5.txt
1775bdcf2ba4e5f4f8a8ceaa38096eec => Assets/TestPackage/C1/C2/C4.txt
1848bef49d02e8c44af44b8717f1a496 => Assets/TestPackage/C1/C6/C8.txt
1d8726fa3eee39943a95a83580da2c61 => Assets/TestPackage/D1.txt
27230fdb56b36814c90250826cd56f79 => Assets/TestPackage/C1/C6/C9.txt
2e06d8c77d037374999c975c00991576 => Assets/TestPackage/A1/A1.txt
360e4170c6c1f64409f7fd13ce68f82b => Assets/TestPackage/A1/A3.txt
411da46bf806e4b499b6f4d07267b1f7 => Assets/TestPackage/A1/A2.txt
483a6065894ccab42b7384cee247c05d => Assets/TestPackage/D2.txt
505ba9c4927610d46aed122fa9c5db07 => Assets/TestPackage/B1/B3/B6.txt
526cf7e31444bf24d93e6a654500feb8 => Assets/TestPackage/C1/C2/C3.txt
747d28cd7a30eba499ad579b52bc52ba => Assets/TestPackage/B1/B2.txt
9dca6c676ab9edf4db2bfac90497b696 => Assets/TestPackage/B1/B3/B4.txt
d5205b85d327c334a89b8dcffb67a04e => Assets/TestPackage/C1/C6/C7.txt
ee03def7a44c22d45900f492dc64ea7c => Assets/TestPackage/B1/B3/B5.txt
```

## Problem case

Absolute path specification. `output_path` is not specified.

```shell
E:\repos\extractunitypackage>python extractunitypackage.py e:\repos\extractunitypackage\sample_asset\sample1.unitypackage
Traceback (most recent call last):
  File "E:\repos\extractunitypackage\extractunitypackage.py", line 84, in <module>
    os.makedirs(outputDir)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  [Previous line repeated 1 more time]
  File "C:\Users\user\AppData\Local\Programs\Python\Python310\lib\os.py", line 225, in makedirs
    mkdir(name, mode)
OSError: [WinError 123] ファイル名、ディレクトリ名、またはボリューム ラベルの構文が間違っています。: './e:'
```



