### PR TITLE
Fixed bug caused by system not defaulting to UTF8 encoding

### DIFF
--- a/extractunitypackage.py
+++ b/extractunitypackage.py
@@ -46,7 +46,7 @@ if os.path.exists(workingDir):
 	shutil.rmtree(workingDir)
 
 # extract .unitypackage contents to a temporary space
-tar = tarfile.open(sys.argv[1], 'r:gz')
+tar = tarfile.open(sys.argv[1], 'r:gz', encoding="utf8")
 tar.extractall(workingDir);
 tar.close()
 
@@ -67,7 +67,7 @@ for i in os.listdir(workingDir):
 		for j in os.listdir(rootFile):
 			# grab the real path
 			if j == 'pathname':
-				lines = [line.strip() for line in open(os.path.join(rootFile, j))]
+				lines = [line.strip() for line in open(os.path.join(rootFile, j), encoding="utf8")]
 				realPath = lines[0]     # should always be on the first line
 			elif j == 'asset':
 				hasAsset = True


### PR DESCRIPTION
I'm not sure exactly what causes this issue but running this script as is causes Python to automatically use CP-1252 encoding on my machine. This would then give me the error `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 8: character maps to <undefined>` on line 70. This can be fixed by manually telling Python to use UTF8 encoding.

While for me it wasn't necessary to specify the encoding on line 49, I'd still do so just to be on the safe side.